### PR TITLE
CAB-3024: Add metrics from SpringBoot2 applications to grafana

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        springBootVersion = '2.0.5.RELEASE'
+        springBootVersion = '2.0.9.RELEASE'
         springCloudReleaseTrain = 'Finchley.SR2'
 
         springDataDynamoDBVersion = '5.0.4'
@@ -66,6 +66,9 @@ dependencies {
 
     compile("edu.uw.edm.gws:gws-client:$gwsClientVersion")
     compile("edu.uw.edm.gws:gws-client-spring-boot-starter:$gwsClientVersion")
+
+    compile('io.micrometer:micrometer-registry-statsd')
+    runtime("org.pcollections:pcollections:3.0.1") // required for micrometer, expected fix in micrometer v1.0.6 (upgrading spring may fix this)
 
     runtime('org.springframework.boot:spring-boot-devtools')
     compileOnly('org.projectlombok:lombok')


### PR DESCRIPTION
Note: currently there are some dependency issues preventing this application from being updated to springboot >2.0.x

- Upgrade to springboot 2.0.9.RELEASE
- include micrometer dependency