### PR TITLE
Updates the prefix to test for docfinity pass-through.

### DIFF
--- a/src/main/java/edu/uw/edm/edmzuulproxy/filter/DocFinityAuditUserFilter.java
+++ b/src/main/java/edu/uw/edm/edmzuulproxy/filter/DocFinityAuditUserFilter.java
@@ -21,7 +21,7 @@ import static org.springframework.cloud.netflix.zuul.filters.support.FilterConst
 @Slf4j
 @Component
 public class DocFinityAuditUserFilter extends ZuulFilter {
-    private static final String DOCFINITY_URI_PREFIX = "/docfinity";
+    private static final String DOCFINITY_URI_PREFIX = "/docfinity/";
 
     private final String headerName;
 

--- a/src/test/java/edu/uw/edm/edmzuulproxy/filter/DocFinityAuditUserFilterTest.java
+++ b/src/test/java/edu/uw/edm/edmzuulproxy/filter/DocFinityAuditUserFilterTest.java
@@ -51,11 +51,11 @@ public class DocFinityAuditUserFilterTest {
         assertFalse(filter.shouldFilter());
 
         // test docfinity
-        mockHttpServletRequest.setRequestURI("/docfinity");
+        mockHttpServletRequest.setRequestURI("/docfinity/");
         assertTrue(filter.shouldFilter());
 
         // test docfinity with casing
-        mockHttpServletRequest.setRequestURI("/DOCFINITY");
+        mockHttpServletRequest.setRequestURI("/DOCFINITY/");
         assertTrue(filter.shouldFilter());
 
         // test docfinity with deep url
@@ -94,7 +94,7 @@ public class DocFinityAuditUserFilterTest {
 
         // assert
         assertThat(mockHttpServletResponse.getStatus(), is(400));
-        assertEquals("Header 'x-audituser' is required for requests to '/docfinity'.",
+        assertEquals("Header 'x-audituser' is required for requests to '/docfinity/'.",
                     RequestContext.getCurrentContext().getResponseBody());
     }
 
@@ -108,7 +108,7 @@ public class DocFinityAuditUserFilterTest {
 
         // assert
         assertThat(mockHttpServletResponse.getStatus(), is(400));
-        assertEquals("Header 'x-audituser' is required for requests to '/docfinity'.",
+        assertEquals("Header 'x-audituser' is required for requests to '/docfinity/'.",
                     RequestContext.getCurrentContext().getResponseBody());
     }
 }


### PR DESCRIPTION
This change allows the /docfinity-services path to not hit this filter.