### PR TITLE
CAB-4548: Adds x-api-key header when making request to /documents/*.

### DIFF
--- a/src/main/java/edu/uw/edm/edmzuulproxy/filter/CertificateAuthenticationFilter.java
+++ b/src/main/java/edu/uw/edm/edmzuulproxy/filter/CertificateAuthenticationFilter.java
@@ -35,6 +35,7 @@ public class CertificateAuthenticationFilter extends ZuulFilter {
     private static final String AUTHORIZATION_HEADER = "authorization";
     private static final String COOKIE_HEADER = "cookie";
     private static final String COOKIE_VALUE = "xsrf-token=edm-token";
+    private static final String X_API_KEY_HEADER = "x-api-key";
     private static final String X_XSRF_TOKEN_HEADER = "x-xsrf-token";
     private static final String X_XSRF_TOKEN_VALUE = "edm-token";
     public static final int CERTIFICATE_AUTHORIZATION_FILTER_ORDER = 2;
@@ -89,11 +90,15 @@ public class CertificateAuthenticationFilter extends ZuulFilter {
             ctx.addZuulRequestHeader(AUTHORIZED_PROFILES_HEADER, profilesHeaderValue);
 
             if (   certificateToApiKeyMap != null && certificateToApiKeyMap.containsKey(certificateName)
-                && zuulRequestURI != null && zuulRequestURI.startsWith("/docfinity/") ) {
+                && zuulRequestURI != null) {
                 String apiKey = certificateToApiKeyMap.get(certificateName);
-                ctx.addZuulRequestHeader(AUTHORIZATION_HEADER, "Bearer " + apiKey);
-                ctx.addZuulRequestHeader(X_XSRF_TOKEN_HEADER, X_XSRF_TOKEN_VALUE);
-                ctx.addZuulRequestHeader(COOKIE_HEADER, COOKIE_VALUE);
+                if (zuulRequestURI.startsWith("/docfinity/")) {
+                    ctx.addZuulRequestHeader(AUTHORIZATION_HEADER, "Bearer " + apiKey);
+                    ctx.addZuulRequestHeader(X_XSRF_TOKEN_HEADER, X_XSRF_TOKEN_VALUE);
+                    ctx.addZuulRequestHeader(COOKIE_HEADER, COOKIE_VALUE);
+                } else if (zuulRequestURI.startsWith("/documents/")) {
+                    ctx.addZuulRequestHeader(X_API_KEY_HEADER, apiKey);
+                }
             }
 
         } catch (Exception e) {

--- a/src/test/java/edu/uw/edm/edmzuulproxy/filter/CertificateAuthenticationFilterTest.java
+++ b/src/test/java/edu/uw/edm/edmzuulproxy/filter/CertificateAuthenticationFilterTest.java
@@ -228,6 +228,24 @@ public class CertificateAuthenticationFilterTest {
         assertThat(cookieHeader, is("xsrf-token=edm-token"));
     }
 
+    @Test
+    public void shouldAddDocfinityHeaderWhenRequestForDocumentApi() {
+        // arrange
+        mockHttpServletRequest.setRequestURI("/documents/create");
+        mockHttpServletRequest.setMethod("GET");
+        mockHttpServletRequest.addHeader(CERTIFICATE_NAME_HEADER, "mycert");
+
+        when(certificateAuthorizerService.isAllowedForUri(any(), any(), any(), any())).thenReturn(true);
+        when(certificateAuthorizerService.getAuthorizedProfilesForUri(any(), any())).thenReturn(Lists.newArrayList("testprofile1", "testprofile2"));
+
+        // act
+        CertificateAuthenticationFilter filter = newFilter();
+        filter.run();
+
+        // assert
+        final String apiKeyHeader = RequestContext.getCurrentContext().getZuulRequestHeaders().get("x-api-key");
+        assertThat(apiKeyHeader, is("apikey"));
+    }
 
     @Test
     public void shouldNotAddDocfinityHeaderToRequestForUnknownCert() {


### PR DESCRIPTION
This allows the Document-API beta to function by making requests with a certificate and is currently deployed as a private branch to DEV environment.

If changes are required post-beta we can make those at a later time.